### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -104,3 +104,23 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+    
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(
+            status_code=400, detail="Student is not signed up for this activity")
+    
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball training and inter-school matches",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu", "sarah@mergington.edu"]
+    },
+    "Swimming Club": {
+        "description": "Swimming techniques and competitive training",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["lucas@mergington.edu", "mia@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and mixed media art",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "ethan@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting, stage performance, and theater production",
+        "schedule": "Thursdays, 3:30 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["isabella@mergington.edu", "noah@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop critical thinking and public speaking skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["liam@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Science Olympiad": {
+        "description": "Compete in science competitions and conduct experiments",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["mason@mergington.edu", "amelia@mergington.edu"]
     }
 }
 
@@ -61,7 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
-
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(
+            status_code=400, detail="Student already signed up for this activity")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,51 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Function to handle participant deletion
+  async function handleDeleteParticipant(event) {
+    const button = event.currentTarget;
+    const activity = button.getAttribute('data-activity');
+    const email = button.getAttribute('data-email');
+
+    if (!confirm(`Are you sure you want to remove ${email} from ${activity}?`)) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+        {
+          method: 'DELETE',
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = 'success';
+        messageDiv.classList.remove('hidden');
+        
+        // Refresh the activities list
+        await fetchActivities();
+
+        // Hide message after 3 seconds
+        setTimeout(() => {
+          messageDiv.classList.add('hidden');
+        }, 3000);
+      } else {
+        messageDiv.textContent = result.detail || 'Failed to remove participant';
+        messageDiv.className = 'error';
+        messageDiv.classList.remove('hidden');
+      }
+    } catch (error) {
+      messageDiv.textContent = 'Failed to remove participant. Please try again.';
+      messageDiv.className = 'error';
+      messageDiv.classList.remove('hidden');
+      console.error('Error removing participant:', error);
+    }
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -27,7 +72,19 @@ document.addEventListener("DOMContentLoaded", () => {
             <div class="participants-section">
               <strong>Participants:</strong>
               <ul class="participants-list">
-                ${details.participants.map(email => `<li>${email}</li>`).join('')}
+                ${details.participants.map(email => `
+                  <li>
+                    <span class="participant-email">${email}</span>
+                    <button class="delete-btn" data-activity="${name}" data-email="${email}" title="Remove participant">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="3 6 5 6 21 6"></polyline>
+                        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                        <line x1="10" y1="11" x2="10" y2="17"></line>
+                        <line x1="14" y1="11" x2="14" y2="17"></line>
+                      </svg>
+                    </button>
+                  </li>
+                `).join('')}
               </ul>
             </div>
           `;
@@ -56,6 +113,11 @@ document.addEventListener("DOMContentLoaded", () => {
         option.textContent = name;
         activitySelect.appendChild(option);
       });
+
+      // Add event listeners for delete buttons
+      document.querySelectorAll('.delete-btn').forEach(button => {
+        button.addEventListener('click', handleDeleteParticipant);
+      });
     } catch (error) {
       activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
       console.error("Error fetching activities:", error);
@@ -83,6 +145,9 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        
+        // Refresh the activities list to show the new participant
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,32 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        // Create participants list
+        let participantsList = '';
+        if (details.participants.length > 0) {
+          participantsList = `
+            <div class="participants-section">
+              <strong>Participants:</strong>
+              <ul class="participants-list">
+                ${details.participants.map(email => `<li>${email}</li>`).join('')}
+              </ul>
+            </div>
+          `;
+        } else {
+          participantsList = `
+            <div class="participants-section">
+              <strong>Participants:</strong>
+              <p class="no-participants">No participants yet. Be the first to sign up!</p>
+            </div>
+          `;
+        }
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          ${participantsList}
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -87,15 +87,55 @@ section h3 {
 
 .participants-list {
   margin-top: 8px;
-  margin-left: 20px;
-  list-style-type: disc;
+  margin-left: 0;
+  list-style-type: none;
+  padding: 0;
 }
 
 .participants-list li {
-  padding: 4px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  margin-bottom: 6px;
   color: #555;
   font-size: 14px;
   line-height: 1.4;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.participants-list li:hover {
+  background-color: #ebebeb;
+}
+
+.participant-email {
+  flex: 1;
+}
+
+.delete-btn {
+  background-color: transparent;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: #c62828;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.2s;
+  margin-left: 8px;
+}
+
+.delete-btn:hover {
+  background-color: #ffebee;
+  color: #b71c1c;
+  transform: scale(1.1);
+}
+
+.delete-btn svg {
+  display: block;
 }
 
 .no-participants {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,37 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 15px;
+  padding-top: 12px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-section strong {
+  color: #1a237e;
+  font-size: 14px;
+}
+
+.participants-list {
+  margin-top: 8px;
+  margin-left: 20px;
+  list-style-type: disc;
+}
+
+.participants-list li {
+  padding: 4px 0;
+  color: #555;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.no-participants {
+  margin-top: 8px;
+  color: #999;
+  font-style: italic;
+  font-size: 14px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the High School Management System API"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,231 @@
+"""
+Test suite for the High School Management System API
+
+Tests cover:
+- Retrieving activities
+- Signing up for activities
+- Unregistering from activities
+- Error handling
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+import copy
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app"""
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset activities to initial state before each test"""
+    # Store original state
+    original_activities = copy.deepcopy(activities)
+    
+    yield
+    
+    # Restore original state after test
+    activities.clear()
+    activities.update(original_activities)
+
+
+class TestRootEndpoint:
+    """Tests for the root endpoint"""
+    
+    def test_root_redirects_to_static(self, client):
+        """Test that root redirects to static/index.html"""
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/static/index.html"
+
+
+class TestGetActivities:
+    """Tests for GET /activities endpoint"""
+    
+    def test_get_all_activities(self, client):
+        """Test retrieving all activities"""
+        response = client.get("/activities")
+        assert response.status_code == 200
+        
+        data = response.json()
+        assert isinstance(data, dict)
+        assert "Chess Club" in data
+        assert "Programming Class" in data
+        assert len(data) == 9  # Should have 9 activities
+    
+    def test_activity_structure(self, client):
+        """Test that activities have correct structure"""
+        response = client.get("/activities")
+        data = response.json()
+        
+        for activity_name, activity_data in data.items():
+            assert "description" in activity_data
+            assert "schedule" in activity_data
+            assert "max_participants" in activity_data
+            assert "participants" in activity_data
+            assert isinstance(activity_data["participants"], list)
+            assert isinstance(activity_data["max_participants"], int)
+
+
+class TestSignup:
+    """Tests for POST /activities/{activity_name}/signup endpoint"""
+    
+    def test_signup_new_participant(self, client):
+        """Test signing up a new participant"""
+        response = client.post(
+            "/activities/Chess%20Club/signup?email=newstudent@mergington.edu"
+        )
+        assert response.status_code == 200
+        
+        data = response.json()
+        assert "message" in data
+        assert "newstudent@mergington.edu" in data["message"]
+        
+        # Verify participant was added
+        assert "newstudent@mergington.edu" in activities["Chess Club"]["participants"]
+    
+    def test_signup_duplicate_participant(self, client):
+        """Test that signing up the same participant twice fails"""
+        email = "duplicate@mergington.edu"
+        
+        # First signup should succeed
+        response1 = client.post(f"/activities/Chess%20Club/signup?email={email}")
+        assert response1.status_code == 200
+        
+        # Second signup should fail
+        response2 = client.post(f"/activities/Chess%20Club/signup?email={email}")
+        assert response2.status_code == 400
+        assert "already signed up" in response2.json()["detail"]
+    
+    def test_signup_nonexistent_activity(self, client):
+        """Test signing up for a non-existent activity"""
+        response = client.post(
+            "/activities/Fake%20Club/signup?email=student@mergington.edu"
+        )
+        assert response.status_code == 404
+        assert "Activity not found" in response.json()["detail"]
+    
+    def test_signup_multiple_activities(self, client):
+        """Test that a student can sign up for multiple activities"""
+        email = "multi@mergington.edu"
+        
+        response1 = client.post(f"/activities/Chess%20Club/signup?email={email}")
+        assert response1.status_code == 200
+        
+        response2 = client.post(f"/activities/Programming%20Class/signup?email={email}")
+        assert response2.status_code == 200
+        
+        assert email in activities["Chess Club"]["participants"]
+        assert email in activities["Programming Class"]["participants"]
+
+
+class TestUnregister:
+    """Tests for DELETE /activities/{activity_name}/unregister endpoint"""
+    
+    def test_unregister_existing_participant(self, client):
+        """Test unregistering an existing participant"""
+        # First sign up
+        email = "temp@mergington.edu"
+        client.post(f"/activities/Chess%20Club/signup?email={email}")
+        
+        # Then unregister
+        response = client.delete(f"/activities/Chess%20Club/unregister?email={email}")
+        assert response.status_code == 200
+        
+        data = response.json()
+        assert "Unregistered" in data["message"]
+        assert email in data["message"]
+        
+        # Verify participant was removed
+        assert email not in activities["Chess Club"]["participants"]
+    
+    def test_unregister_non_participant(self, client):
+        """Test unregistering someone who isn't signed up"""
+        response = client.delete(
+            "/activities/Chess%20Club/unregister?email=notregistered@mergington.edu"
+        )
+        assert response.status_code == 400
+        assert "not signed up" in response.json()["detail"]
+    
+    def test_unregister_nonexistent_activity(self, client):
+        """Test unregistering from a non-existent activity"""
+        response = client.delete(
+            "/activities/Fake%20Club/unregister?email=student@mergington.edu"
+        )
+        assert response.status_code == 404
+        assert "Activity not found" in response.json()["detail"]
+    
+    def test_unregister_preserves_other_participants(self, client):
+        """Test that unregistering one participant doesn't affect others"""
+        # Get initial participants
+        initial_participants = activities["Chess Club"]["participants"].copy()
+        
+        # Add a new participant
+        new_email = "newtemp@mergington.edu"
+        client.post(f"/activities/Chess%20Club/signup?email={new_email}")
+        
+        # Unregister the new participant
+        client.delete(f"/activities/Chess%20Club/unregister?email={new_email}")
+        
+        # Verify original participants are still there
+        for participant in initial_participants:
+            assert participant in activities["Chess Club"]["participants"]
+        
+        # Verify new participant was removed
+        assert new_email not in activities["Chess Club"]["participants"]
+
+
+class TestIntegration:
+    """Integration tests for complete workflows"""
+    
+    def test_full_signup_unregister_workflow(self, client):
+        """Test complete workflow of signing up and unregistering"""
+        email = "workflow@mergington.edu"
+        activity = "Programming Class"
+        
+        # Check initial state
+        initial_count = len(activities[activity]["participants"])
+        
+        # Sign up
+        signup_response = client.post(
+            f"/activities/{activity.replace(' ', '%20')}/signup?email={email}"
+        )
+        assert signup_response.status_code == 200
+        assert len(activities[activity]["participants"]) == initial_count + 1
+        
+        # Verify participant is in the list
+        assert email in activities[activity]["participants"]
+        
+        # Get activities and verify
+        get_response = client.get("/activities")
+        assert get_response.status_code == 200
+        assert email in get_response.json()[activity]["participants"]
+        
+        # Unregister
+        unregister_response = client.delete(
+            f"/activities/{activity.replace(' ', '%20')}/unregister?email={email}"
+        )
+        assert unregister_response.status_code == 200
+        assert len(activities[activity]["participants"]) == initial_count
+        
+        # Verify participant is removed
+        assert email not in activities[activity]["participants"]
+    
+    def test_activity_capacity_tracking(self, client):
+        """Test that activity capacity is properly tracked"""
+        response = client.get("/activities")
+        data = response.json()
+        
+        for activity_name, activity_data in data.items():
+            current_participants = len(activity_data["participants"])
+            max_participants = activity_data["max_participants"]
+            
+            # Verify we haven't exceeded capacity
+            assert current_participants <= max_participants
+            
+            # Verify capacity is positive
+            assert max_participants > 0


### PR DESCRIPTION
This pull request adds the ability for users to unregister from activities, enhances the frontend to display and manage participants for each activity, improves user feedback, and introduces a comprehensive test suite to ensure API reliability. The main themes are backend API enhancements, frontend UI/UX improvements, and expanded testing.

**Backend API Enhancements:**

* Added an endpoint to allow users to unregister from activities, including validation to ensure the student is signed up before removal (`src/app.py`).
* Updated the signup logic to prevent duplicate signups for the same activity (`src/app.py`).

**Frontend UI/UX Improvements:**

* Displayed a participant list for each activity, including a delete button next to each participant for easy removal (`src/static/app.js`).
* Implemented frontend logic to handle participant removal, including confirmation dialogs, API calls, and user feedback messages (`src/static/app.js`). [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R51) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R116-R120)
* Improved styles for the participant list and delete button for better usability and appearance (`src/static/styles.css`).

**Testing and Quality Assurance:**

* Introduced a comprehensive test suite covering activity retrieval, signup, unregister, error handling, and integration workflows (`tests/test_api.py`).
* Added a module docstring to clarify the purpose of the test package (`tests/__init__.py`).

**Data Expansion:**

* Added several new activities (e.g., Basketball Team, Swimming Club, Art Studio, Drama Club, Debate Team, Science Olympiad) to the initial data set (`src/app.py`).https://github.com/TazeenGL/skills-getting-started-with-github-copilot